### PR TITLE
Require Comply or explain for the standard

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,3 +2,7 @@
 
 The Amsterdam development standard documents the specific technology, tools and processes that DataPunt teams use to build and operate services.
 
+## Comply or explain
+
+These standards are agreements to make it easier to work together, if there is a good reason to not follow one of the standards you are free to diverge, however you **must** explain in your commit message, pull request or `README` why you did this.
+


### PR DESCRIPTION
By using _Comply or explain_, known in Dutch as 'Pas toe of leg uit' we can make sure nobody is overly bound by these standards by always allowing exceptions where made consciously. Exceptions just have to be publicly documented.